### PR TITLE
Makefile.common has moved slightly

### DIFF
--- a/c_data_specification/Makefile
+++ b/c_data_specification/Makefile
@@ -18,8 +18,9 @@ OBJECTS = data_specification_executor.o data_specification_stack.o struct.o c_ma
 CFLAGS += -DPRODUCTION_CODE
 
 # The spinnaker_tools standard makefile
-include $(SPINN_DIRS)/Makefile.common
+include $(SPINN_DIRS)/make/Makefile.common
 
+$(shell mkdir build)
 all: $(APP_OUTPUT_DIR)$(APP).aplx
 
 clean:


### PR DESCRIPTION
Since the last time this code was regularly built, `Makefile.common` has been relocated from `$(SPINN_DIRS)` to `$(SPINN_DIRS)/make`. Also, it's now necessary to make the `build` directory or the build fails.