### PR TITLE
Allow uncompressed

### DIFF
--- a/data_specification/data_specification_executor.py
+++ b/data_specification/data_specification_executor.py
@@ -134,10 +134,12 @@ class DataSpecificationExecutor(object):
                 if ((memory_region.unfilled and
                     self.dsef.mem_regions.needs_to_write_region(i)) or
                         not memory_region.unfilled):
+                    max_pointer = memory_region.max_write_pointer
+                    if not memory_region.shrink:
+                        max_pointer = memory_region.allocated_size
                     self.mem_writer.write(memory_region.region_data[
-                        :memory_region.max_write_pointer])
-                else:
-                    self.space_written -= memory_region.allocated_size
+                        :max_pointer])
+                self.space_written -= memory_region.allocated_size
 
     def write_dse_region_output_file(self, region_to_write):
         """ supports writing a specific region instead of the entire DSE file
@@ -151,10 +153,12 @@ class DataSpecificationExecutor(object):
                     self.dsef.mem_regions.needs_to_write_region(
                         region_to_write)) or
                     not memory_region.unfilled):
-                self.mem_writer.write(memory_region.region_data[
-                                      :memory_region.max_write_pointer])
-            else:
-                self.space_written -= memory_region.allocated_size
+                max_pointer = memory_region.max_write_pointer
+                if not memory_region.shrink:
+                    max_pointer = memory_region.allocated_size
+                self.mem_writer.write(memory_region.region_data[:max_pointer])
+
+            self.space_written -= memory_region.allocated_size
 
     def write_header(self):
         """ writes the DSE header which resides at the top of any cores\

--- a/data_specification/data_specification_executor.py
+++ b/data_specification/data_specification_executor.py
@@ -211,8 +211,11 @@ class DataSpecificationExecutor(object):
             memory_region = self.dsef.mem_regions[i]
             if memory_region is not None:
                 pointer_table[i] = next_free_offset + start_address
-                self.space_used += memory_region.allocated_size
-                next_free_offset += memory_region.allocated_size
+                max_pointer = memory_region.max_write_pointer
+                if not memory_region.shrink or memory_region.unfilled:
+                    max_pointer = memory_region.allocated_size
+                self.space_used += max_pointer
+                next_free_offset += max_pointer
             else:
                 pointer_table[i] = 0
 

--- a/data_specification/data_specification_executor.py
+++ b/data_specification/data_specification_executor.py
@@ -211,15 +211,10 @@ class DataSpecificationExecutor(object):
             memory_region = self.dsef.mem_regions[i]
             if memory_region is not None:
                 pointer_table[i] = next_free_offset + start_address
-                if memory_region.unfilled or not memory_region.shrink:
-                    region_size = memory_region.allocated_size
-                else:
-                    region_size = memory_region.max_write_pointer
+                self.space_used += memory_region.allocated_size
+                next_free_offset += memory_region.allocated_size
             else:
                 pointer_table[i] = 0
-                region_size = 0
-            self.space_used += region_size
-            next_free_offset += region_size
 
         index = 0
         for i in pointer_table:

--- a/data_specification/data_specification_executor.py
+++ b/data_specification/data_specification_executor.py
@@ -204,7 +204,7 @@ class DataSpecificationExecutor(object):
             memory_region = self.dsef.mem_regions[i]
             if memory_region is not None:
                 pointer_table[i] = next_free_offset + start_address
-                if memory_region.unfilled:
+                if memory_region.unfilled or not memory_region.shrink:
                     region_size = memory_region.allocated_size
                 else:
                     region_size = memory_region.max_write_pointer

--- a/data_specification/data_specification_executor.py
+++ b/data_specification/data_specification_executor.py
@@ -135,7 +135,7 @@ class DataSpecificationExecutor(object):
                     self.dsef.mem_regions.needs_to_write_region(i)) or
                         not memory_region.unfilled):
                     max_pointer = memory_region.max_write_pointer
-                    if not memory_region.shrink:
+                    if not memory_region.shrink or memory_region.unfilled:
                         max_pointer = memory_region.allocated_size
                     self.mem_writer.write(memory_region.region_data[
                         :max_pointer])
@@ -154,7 +154,7 @@ class DataSpecificationExecutor(object):
                         region_to_write)) or
                     not memory_region.unfilled):
                 max_pointer = memory_region.max_write_pointer
-                if not memory_region.shrink:
+                if not memory_region.shrink or memory_region.unfilled:
                     max_pointer = memory_region.allocated_size
                 self.mem_writer.write(memory_region.region_data[:max_pointer])
 

--- a/data_specification/data_specification_executor.py
+++ b/data_specification/data_specification_executor.py
@@ -145,20 +145,23 @@ class DataSpecificationExecutor(object):
         """ supports writing a specific region instead of the entire DSE file
 
         :param region_to_write: the dsg region to write
-        :rtype: None
+        :rtype: int
         """
         memory_region = self.dsef.mem_regions[region_to_write]
         if memory_region is not None:
-            if ((memory_region.unfilled and
-                    self.dsef.mem_regions.needs_to_write_region(
-                        region_to_write)) or
-                    not memory_region.unfilled):
-                max_pointer = memory_region.max_write_pointer
-                if not memory_region.shrink or memory_region.unfilled:
-                    max_pointer = memory_region.allocated_size
-                self.mem_writer.write(memory_region.region_data[:max_pointer])
+            self.mem_writer.write(
+                memory_region.region_data[:memory_region.max_write_pointer])
+            return memory_region.max_write_pointer
+        return 0
 
-            self.space_written -= memory_region.allocated_size
+    def get_region(self, region_id):
+        """ Get a region with a given id
+
+        :param region_id: The id of the region to get
+        :type region_id: int
+        :return: The region, or None if the region was not allocated
+        """
+        return self.dsef.mem_regions[region_id]
 
     def write_header(self):
         """ writes the DSE header which resides at the top of any cores\

--- a/data_specification/data_specification_executor_functions.py
+++ b/data_specification/data_specification_executor_functions.py
@@ -171,6 +171,7 @@ class DataSpecificationExecutorFunctions(object):
                     "RESERVE", cmd, self._cmd_size))
 
         unfilled = (cmd >> 7) & 0x1 == 0x1
+        shrink = (cmd >> 6) & 0x1 == 0x1
 
         if not self.mem_regions.is_empty(region):
             raise exceptions.DataSpecificationRegionInUseException(region)
@@ -185,7 +186,7 @@ class DataSpecificationExecutorFunctions(object):
                 "region size", size, 1, self.memory_space, "RESERVE")
 
         self.mem_regions[region] = MemoryRegion(
-            memory_pointer=0, unfilled=unfilled, size=size)
+            memory_pointer=0, unfilled=unfilled, size=size, shrink=shrink)
         self.space_allocated += size
 
     def execute_free(self, cmd):

--- a/data_specification/data_specification_generator.py
+++ b/data_specification/data_specification_generator.py
@@ -193,23 +193,19 @@ class DataSpecificationGenerator(object):
                 sdram.SDRAM.DEFAULT_SDRAM_BYTES,
                 Commands.RESERVE.name)  # @UndefinedVariable
 
-        unfilled = False
-        if empty:
-            unfilled = True
-
-        self.mem_slot[region] = [size, label, unfilled]
+        self.mem_slot[region] = [size, label, empty]
 
         cmd_word = ((constants.LEN2 << 28) |
                     (Commands.RESERVE.value << 20) |  # @UndefinedVariable
                     (constants.NO_REGS << 16) |
-                    (unfilled << 7) |
-                    (shrink << 6) |
+                    (int(bool(empty)) << 7) |
+                    (int(bool(shrink)) << 6) |
                     region)
         encoded_cmd_word = bytearray(struct.pack("<I", cmd_word))
         encoded_size = bytearray(struct.pack("<I", size))
         cmd_word_list = encoded_cmd_word + encoded_size
 
-        if unfilled:
+        if empty:
             unfilled_string = "UNFILLED"
         else:
             unfilled_string = ""

--- a/data_specification/data_specification_generator.py
+++ b/data_specification/data_specification_generator.py
@@ -143,7 +143,8 @@ class DataSpecificationGenerator(object):
         self.write_command_to_files(cmd_word_list, cmd_string)
         return
 
-    def reserve_memory_region(self, region, size, label=None, empty=False):
+    def reserve_memory_region(
+            self, region, size, label=None, empty=False, shrink=True):
         """ Insert command to reserve a memory region
 
         :param region: The number of the region to reserve, from 0 to 15
@@ -154,6 +155,8 @@ class DataSpecificationGenerator(object):
         :type label: str
         :param empty: Specifies if the region will be left empty
         :type empty: bool
+        :param shrink: Specifies if the region will be compressed
+        :type shrink: bool
         :return: Nothing is returned
         :rtype: None
         :raise data_specification.exceptions.DataUndefinedWriterException:\
@@ -200,7 +203,7 @@ class DataSpecificationGenerator(object):
                     (Commands.RESERVE.value << 20) |  # @UndefinedVariable
                     (constants.NO_REGS << 16) |
                     (unfilled << 7) |
-                    (1 << 6) |
+                    (shrink << 6) |
                     region)
         encoded_cmd_word = bytearray(struct.pack("<I", cmd_word))
         encoded_size = bytearray(struct.pack("<I", size))

--- a/data_specification/memory_region.py
+++ b/data_specification/memory_region.py
@@ -21,10 +21,13 @@ class MemoryRegion(object):
         "_write_pointer",
 
         # the max point where if written over, it will cause an error
-        "_max_write_pointer"
+        "_max_write_pointer",
+
+        # Whether to shrink the region or not
+        "_shrink"
     ]
 
-    def __init__(self, memory_pointer, unfilled, size):
+    def __init__(self, memory_pointer, unfilled, size, shrink):
         """
 
         :param memory_pointer: the write pointer position
@@ -38,6 +41,7 @@ class MemoryRegion(object):
         self._region_data = bytearray(size)
         self._write_pointer = 0
         self._max_write_pointer = 0
+        self._shrink = shrink
 
     @property
     def memory_pointer(self):
@@ -97,3 +101,7 @@ class MemoryRegion(object):
         self._write_pointer += n_bytes
         self._max_write_pointer = max((
             self._write_pointer, self._max_write_pointer))
+
+    @property
+    def shrink(self):
+        return self._shrink


### PR DESCRIPTION
Allows regions to be left uncompressed.  Allows the reservation of space in a region which is then not used directly, but is needed later.