### PR TITLE
A better way of locating the DSE on-chip executable

### DIFF
--- a/data_specification/data_spec_sender/__init__.py
+++ b/data_specification/data_spec_sender/__init__.py
@@ -1,0 +1,13 @@
+import os.path
+
+
+def data_specification_executor():
+    """ Get the name of the executable for the on-chip DSE.
+
+    :return: A fully-qualified filename.
+    """
+    return os.path.join(os.path.dirname(__file__),
+                        "data_specification_executor.aplx")
+
+
+__all__ = ["data_specification_executor"]

--- a/data_specification/data_spec_sender/spec_sender.py
+++ b/data_specification/data_spec_sender/spec_sender.py
@@ -1,9 +1,0 @@
-"""
-    Empty file to help FrontEndCommonMachineExecuteDataSpecification find
-    data_specification/data_spec_sender/data_specification_executor.aplx
-
-"""
-
-
-def location():
-    return __file__


### PR DESCRIPTION
This is a less ugly way of locating the DSE on-chip executable; we can know exactly where it is and what it is called and make it all relatively pythonic too.