### PR TITLE
Gcc update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,25 @@
 language: python
+dist: xenial
 matrix:
   include:
     - python: 2.7
-      dist: trusty
       sudo: false
-      addons:
-        apt:
-          packages:
-            - vera++
-            - cutter-testing-framework-bin
     - python: 3.6
-      dist: trusty
       sudo: false
-      addons:
-        apt:
-          packages:
-            - vera++
-            - cutter-testing-framework-bin
     - python: 3.7
-      dist: xenial
       sudo: true
       addons:
         apt:
           sources:
             - sourceline: 'ppa:cutter-testing-framework/ppa'
-          packages:
-            - vera++
-            - cutter-testing-framework
+addons:
+  apt:
+    packages:
+      - vera++
+      - cutter-testing-framework
+      - gcc-arm-none-eabi
+      - libnewlib-arm-none-eabi
 cache: pip
-
 
 before_install:
   # Work around ludicrous Travis bug
@@ -46,6 +37,7 @@ install:
   - pip install python-coveralls 'coverage>=4.4'
   - python ./setup.py install
   # C build checks
+  
   - make -C c_data_specification -f test.mk build-test
   # TODO: ensure that the C data spec also builds with the embedded compiler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,21 +26,28 @@ before_install:
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNUtils.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNMachine.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNStorageHandlers.git
+  # C dependencies
+  - support/gitclone.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
+  - export SPINN_DIRS=$PWD/spinnaker_tools CFLAGS=-fdiagnostics-color
+
+before_install:
+  # Initialise builds against spinnaker_tools
+  - make -C $SPINN_DIRS
 
 install:
   - pip install -r requirements-test.txt
   - pip install python-coveralls 'coverage>=4.4'
   - python ./setup.py install
-  # C build checks
-  
+  # C build, emulation mode for testing
   - make -C c_data_specification -f test.mk build-test
-  # TODO: ensure that the C data spec also builds with the embedded compiler
 
 script:
   # Tests
   - py.test unittests --cov data_specification
   - py.test integration_tests --cov data_specification --cov-append
   - make -C c_data_specification -f test.mk check
+  # C build checks
+  - make -C c_data_specification clean all
   # Code quality check
   - flake8 data_specification
   - flake8 unittests integration_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: python
 dist: xenial
-matrix:
-  include:
-    - python: 2.7
-      sudo: false
-    - python: 3.6
-      sudo: false
-    - python: 3.7
-      sudo: true
-      addons:
-        apt:
-          sources:
-            - sourceline: 'ppa:cutter-testing-framework/ppa'
+python:
+  - 2.7
+  - 3.6
+  - 3.7
+sudo: true
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:cutter-testing-framework/ppa'
     packages:
       - vera++
       - cutter-testing-framework

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ before_install:
   - support/gitclone.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
   - export SPINN_DIRS=$PWD/spinnaker_tools CFLAGS=-fdiagnostics-color
 
-before_install:
-  # Initialise builds against spinnaker_tools
-  - make -C $SPINN_DIRS
-
 install:
   - pip install -r requirements-test.txt
   - pip install python-coveralls 'coverage>=4.4'
   - python ./setup.py install
   # C build, emulation mode for testing
   - make -C c_data_specification -f test.mk build-test
+
+before_script:
+  # Initialise builds against spinnaker_tools
+  - make -C $SPINN_DIRS
 
 script:
   # Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNStorageHandlers.git
   # C dependencies
   - support/gitclone.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
+  - support/gitclone.sh https://github.com/SpiNNakerManchester/spinn_common.git
   - export SPINN_DIRS=$PWD/spinnaker_tools CFLAGS=-fdiagnostics-color
 
 install:
@@ -40,6 +41,7 @@ install:
 before_script:
   # Initialise builds against spinnaker_tools
   - make -C $SPINN_DIRS
+  - make -C spinn_common install
 
 script:
   # Tests

--- a/c_data_specification/system_api.h
+++ b/c_data_specification/system_api.h
@@ -43,7 +43,7 @@ typedef uint32_t* address_t;
 
 #else // !EMULATE
 #include <spin1_api.h>
-#include <debug.h>
+#include <assert.h>
 #include <spinnaker.h>
 #include <data_specification.h>
 #endif // EMULATE


### PR DESCRIPTION
This branch was originally to update GCC to produce colour output and get Travis building this last corner of code automatically. It does that, but the code in question is broken because **it depends on a header in SpiNNFrontEndCommon** (`data_specification.h`).