### PR TITLE
Quell some (lots!) warnings in sPyNNaker8

### DIFF
--- a/data_specification/enums/data_type.py
+++ b/data_specification/enums/data_type.py
@@ -28,6 +28,7 @@ class DataType(Enum):
              decimal.Decimal("1"),
              "B",
              False,
+             int,
              np.uint8,
              "8-bit unsigned integer")
     UINT16 = (1,
@@ -37,6 +38,7 @@ class DataType(Enum):
               decimal.Decimal("1"),
               "H",
               False,
+              int,
               np.uint16,
               "16-bit unsigned integer")
     UINT32 = (2,
@@ -46,6 +48,7 @@ class DataType(Enum):
               decimal.Decimal("1"),
               "I",
               False,
+              int,
               np.uint32,
               "32-bit unsigned integer")
     UINT64 = (3,
@@ -55,6 +58,7 @@ class DataType(Enum):
               decimal.Decimal("1"),
               "Q",
               False,
+              int,
               np.uint64,
               "64-bit unsigned integer")
     INT8 = (4,
@@ -64,6 +68,7 @@ class DataType(Enum):
             decimal.Decimal("1"),
             "b",
             False,
+            int,
             np.int8,
             "8-bit signed integer")
     INT16 = (5,
@@ -73,6 +78,7 @@ class DataType(Enum):
              decimal.Decimal("1"),
              "h",
              False,
+             int,
              np.int16,
              "16-bit signed integer")
     INT32 = (6,
@@ -82,6 +88,7 @@ class DataType(Enum):
              decimal.Decimal("1"),
              "i",
              False,
+             int,
              np.int32,
              "32-bit signed integer")
     INT64 = (7,
@@ -91,6 +98,7 @@ class DataType(Enum):
              decimal.Decimal("1"),
              "q",
              False,
+             int,
              np.int64,
              "64-bit signed integer")
     U88 = (8,
@@ -101,6 +109,7 @@ class DataType(Enum):
            "H",
            True,
            None,
+           None,
            "8.8 unsigned fixed point number")
     U1616 = (9,
              4,
@@ -109,6 +118,7 @@ class DataType(Enum):
              decimal.Decimal("65536"),
              "I",
              True,
+             None,
              None,
              "16.16 unsigned fixed point number")
     U3232 = (10,
@@ -119,6 +129,7 @@ class DataType(Enum):
              "Q",
              True,
              None,
+             None,
              "32.32 unsigned fixed point number")  # rounding problem for max
     S87 = (11,
            2,
@@ -127,6 +138,7 @@ class DataType(Enum):
            decimal.Decimal("128"),
            "h",
            True,
+           None,
            None,
            "8.7 signed fixed point number")
     S1615 = (12,
@@ -137,6 +149,7 @@ class DataType(Enum):
              "i",
              True,
              None,
+             None,
              "16.15 signed fixed point number")
     S3231 = (13,
              8,
@@ -146,6 +159,7 @@ class DataType(Enum):
              "q",
              True,
              None,
+             None,
              "32.31 signed fixed point number")  # rounding problem for max
     FLOAT_32 = (14,
                 4,
@@ -154,6 +168,7 @@ class DataType(Enum):
                 decimal.Decimal("1"),
                 "f",
                 False,
+                float,
                 np.float32,
                 "32-bit floating point number")
     FLOAT_64 = (15,
@@ -163,6 +178,7 @@ class DataType(Enum):
                 decimal.Decimal("1"),
                 "d",
                 False,
+                float,
                 np.float64,
                 "64-bit floating point number")
     U08 = (16,
@@ -173,6 +189,7 @@ class DataType(Enum):
            "B",
            True,
            None,
+           None,
            "0.8 unsigned fixed point number")
     U016 = (17,
             2,
@@ -182,6 +199,7 @@ class DataType(Enum):
             "H",
             True,
             None,
+            None,
             "0.16 unsigned fixed point number")
     U032 = (18,
             4,
@@ -190,6 +208,7 @@ class DataType(Enum):
             decimal.Decimal("4294967296"),
             "I",
             True,
+            None,
             None,
             "0.32 unsigned fixed point number")
     U064 = (19,
@@ -201,6 +220,7 @@ class DataType(Enum):
             "Q",
             True,
             None,
+            None,
             "0.64 unsigned fixed point number")  # rounding problem for max
     S07 = (20,
            1,
@@ -209,6 +229,7 @@ class DataType(Enum):
            decimal.Decimal("128"),
            "b",
            True,
+           None,
            None,
            "0.7 signed fixed point number")
     S015 = (21,
@@ -219,6 +240,7 @@ class DataType(Enum):
             "h",
             True,
             None,
+            None,
             "0.15 signed fixed point number")
     S031 = (22,
             4,
@@ -227,6 +249,7 @@ class DataType(Enum):
             decimal.Decimal("2147483648"),
             "i",
             True,
+            None,
             None,
             "0.32 signed fixed point number")
     S063 = (23,
@@ -238,10 +261,11 @@ class DataType(Enum):
             "q",
             True,
             None,
+            None,
             "0.63 signed fixed point number")  # rounding problem for max
 
     def __new__(cls, value, size, min_val, max_val, scale, struct_encoding,
-                apply_scale, numpy_typename, doc=""):
+                apply_scale, force_cast, numpy_typename, doc=""):
         # pylint: disable=protected-access, too-many-arguments
         obj = object.__new__(cls)
         obj._value_ = value
@@ -253,6 +277,7 @@ class DataType(Enum):
         obj.struct_encoding = struct_encoding
         obj.numpy_typename = numpy_typename
         obj._apply_scale = apply_scale
+        obj._force_cast = force_cast
         if size == 1:
             struct_encoding += "xxx"
         elif size == 2:
@@ -261,7 +286,7 @@ class DataType(Enum):
         return obj
 
     def __init__(self, value, size, min_val, max_val, scale, struct_encoding,
-                 apply_scale, numpy_typename, doc=""):
+                 apply_scale, force_cast, numpy_typename, doc=""):
         # pylint: disable=too-many-arguments
         self._value_ = value
         self.__doc__ = doc
@@ -272,6 +297,7 @@ class DataType(Enum):
         self.struct_encoding = struct_encoding
         self.numpy_typename = numpy_typename
         self._apply_scale = apply_scale
+        self._force_cast = force_cast
         if size == 1:
             struct_encoding += "xxx"
         elif size == 2:
@@ -283,4 +309,6 @@ class DataType(Enum):
         """
         if self._apply_scale:
             value = int(decimal.Decimal(str(value)) * self.scale)
+        elif self._force_cast is not None:
+            value = self._force_cast(value)
         return self._struct.pack(value)


### PR DESCRIPTION
There's an enormous number of silly warnings turning up when we test sPyNNaker8. This should silence them.