### PR TITLE
Fix readthedocs issues

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,5 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
--e git+https://github.com/SpiNNakerManchester/SpiNNUtils.git@master#egg=SpiNNUtilities
--e git+https://github.com/SpiNNakerManchester/SpiNNMachine.git@master#egg=SpiNNMachine
+version: 2
+build:
+  image: latest
+sphinx:
+  configuration: doc/source/conf.py
+  builder: dirhtml
+  fail_on_warning: false
+formats: [pdf]  # This is ADDITIONAL to HTML
+python:
+  version: 3.8
+  install:
+    - requirements: doc/doc_requirements.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -362,7 +362,7 @@ autoclass_content = 'both'
 
 # We want to document __call__ when encountered
 autodoc_default_options = {
-    "members": True,
+    "members": None,
     "special-members": "__call__"
 }
 


### PR DESCRIPTION
Fixes:

* Error in egg name in requirements
* Error in `conf.py` (found because RTD uses an old Sphinx; see SpiNNakerManchester/PACMAN#357)
* Made at least _most_ of the RTD config explicit (https://docs.readthedocs.io/en/stable/config-file/v2.html)