### PR TITLE
Increase possible number of regions to 32

### DIFF
--- a/data_specification/constants.py
+++ b/data_specification/constants.py
@@ -29,23 +29,23 @@ DSE_VERSION = 0x00010000
 
 # DSG Arrays and tables sizes:
 #: Maximum number of registers in DSG virtual machine.
-MAX_REGISTERS = 16
+MAX_REGISTERS = 32
 #: Maximum number of memory regions in DSG virtual machine.
-MAX_MEM_REGIONS = 16
+MAX_MEM_REGIONS = 32
 #: Maximum number of structure slots in DSG virtual machine.
-MAX_STRUCT_SLOTS = 16
+MAX_STRUCT_SLOTS = 32
 #: Maximum number of structure elements in DSG virtual machine.
 MAX_STRUCT_ELEMENTS = 255
 #: Maximum number of packing specification slots in DSG virtual machine.
-MAX_PACKSPEC_SLOTS = 16
+MAX_PACKSPEC_SLOTS = 32
 #: Maximum number of functions in DSG virtual machine.
-MAX_CONSTRUCTORS = 16
+MAX_CONSTRUCTORS = 32
 #: Maximum number of parameter lists in DSG virtual machine.
-MAX_PARAM_LISTS = 16
+MAX_PARAM_LISTS = 32
 #: Maximum number of random number generators in DSG virtual machine.
-MAX_RNGS = 16
+MAX_RNGS = 32
 #: Maximum number of random distributions in DSG virtual machine.
-MAX_RANDOM_DISTS = 16
+MAX_RANDOM_DISTS = 32
 
 #: Size of header of data spec pointer table produced by DSE, in bytes.
 APP_PTR_TABLE_HEADER_BYTE_SIZE = 8

--- a/data_specification/constants.py
+++ b/data_specification/constants.py
@@ -29,23 +29,23 @@ DSE_VERSION = 0x00010000
 
 # DSG Arrays and tables sizes:
 #: Maximum number of registers in DSG virtual machine.
-MAX_REGISTERS = 32
+MAX_REGISTERS = 16
 #: Maximum number of memory regions in DSG virtual machine.
 MAX_MEM_REGIONS = 32
 #: Maximum number of structure slots in DSG virtual machine.
-MAX_STRUCT_SLOTS = 32
+MAX_STRUCT_SLOTS = 16
 #: Maximum number of structure elements in DSG virtual machine.
 MAX_STRUCT_ELEMENTS = 255
 #: Maximum number of packing specification slots in DSG virtual machine.
-MAX_PACKSPEC_SLOTS = 32
+MAX_PACKSPEC_SLOTS = 16
 #: Maximum number of functions in DSG virtual machine.
-MAX_CONSTRUCTORS = 32
+MAX_CONSTRUCTORS = 16
 #: Maximum number of parameter lists in DSG virtual machine.
-MAX_PARAM_LISTS = 32
+MAX_PARAM_LISTS = 16
 #: Maximum number of random number generators in DSG virtual machine.
-MAX_RNGS = 32
+MAX_RNGS = 16
 #: Maximum number of random distributions in DSG virtual machine.
-MAX_RANDOM_DISTS = 32
+MAX_RANDOM_DISTS = 16
 
 #: Size of header of data spec pointer table produced by DSE, in bytes.
 APP_PTR_TABLE_HEADER_BYTE_SIZE = 8

--- a/data_specification/data_specification_executor_functions.py
+++ b/data_specification/data_specification_executor_functions.py
@@ -280,7 +280,7 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
         if self.__src1_reg is not None:
             region = self._registers[self.__src1_reg]
         else:
-            region = (cmd >> 8) & 0xF
+            region = (cmd >> 8) & 0x1F
 
         if self._mem_regions.is_empty(region):
             raise RegionUnfilledException(region, "SWITCH_FOCUS")

--- a/data_specification/data_specification_generator.py
+++ b/data_specification/data_specification_generator.py
@@ -765,7 +765,8 @@ class DataSpecificationGenerator(object):
                 _Field.IMMEDIATE: structure_id})
             cmd_string += "repeats=reg[{0:d}]".format(repeats)
         else:
-            _bounds(Commands.WRITE_STRUCT, "repeats", repeats, 0, 16)
+            _bounds(Commands.WRITE_STRUCT, "repeats",
+                    repeats, 0, MAX_STRUCT_SLOTS)
             cmd_word = _binencode(Commands.WRITE_STRUCT, {
                 _Field.LENGTH: LEN1,
                 _Field.SOURCE_1: repeats,

--- a/unittests/test_data_spec_generator.py
+++ b/unittests/test_data_spec_generator.py
@@ -1170,7 +1170,7 @@ class TestDataSpecGeneration(unittest.TestCase):
         with self.assertRaises(ParameterOutOfBoundsException):
             self.dsg.write_structure(-1)
         with self.assertRaises(ParameterOutOfBoundsException):
-            self.dsg.write_structure(16)
+            self.dsg.write_structure(32)
 
         self.skip_words(15)
         # WRITE_STRUCT


### PR DESCRIPTION
The number of regions now required in the neuron code has increased to 17, so this PR ups the maximum from 16 to 32.

Merge along with https://github.com/SpiNNakerManchester/sPyNNaker/pull/1076 and other associated PRs.