### PR TITLE
comment out unused  Decoded from command: operation code

### DIFF
--- a/data_specification/data_specification_executor_functions.py
+++ b/data_specification/data_specification_executor_functions.py
@@ -57,7 +57,7 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
 
         # Decodings of the current command
         "__cmd_size",
-        "__opcode",
+        # "__opcode",
         "__dest_reg",
         "__src1_reg",
         "__src2_reg",
@@ -91,8 +91,8 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
 
         #: Decoded from command: size in words
         self.__cmd_size = None
-        #: Decoded from command: operation code
-        self.__opcode = None
+        # Decoded from command: operation code
+        # self.__opcode = None
         #: Decoded from command: destination register or None
         self.__dest_reg = None
         #: Decoded from command: first source register or None
@@ -117,7 +117,7 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
         :param int cmd: The command read form the data spec file
         """
         self.__cmd_size = (cmd >> 28) & 0x3
-        self.__opcode = (cmd >> 20) & 0xFF
+        # self.__opcode = (cmd >> 20) & 0xFF
         use_dest_reg = (cmd >> 18) & 0x1 == 0x1
         use_src1_reg = (cmd >> 17) & 0x1 == 0x1
         use_src2_reg = (cmd >> 16) & 0x1 == 0x1

--- a/data_specification/data_specification_executor_functions.py
+++ b/data_specification/data_specification_executor_functions.py
@@ -57,7 +57,6 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
 
         # Decodings of the current command
         "__cmd_size",
-        # "__opcode",
         "__dest_reg",
         "__src1_reg",
         "__src2_reg",
@@ -91,8 +90,6 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
 
         #: Decoded from command: size in words
         self.__cmd_size = None
-        # Decoded from command: operation code
-        # self.__opcode = None
         #: Decoded from command: destination register or None
         self.__dest_reg = None
         #: Decoded from command: first source register or None
@@ -117,7 +114,6 @@ class DataSpecificationExecutorFunctions(AbstractExecutorFunctions):
         :param int cmd: The command read form the data spec file
         """
         self.__cmd_size = (cmd >> 28) & 0x3
-        # self.__opcode = (cmd >> 20) & 0xFF
         use_dest_reg = (cmd >> 18) & 0x1 == 0x1
         use_src1_reg = (cmd >> 17) & 0x1 == 0x1
         use_src2_reg = (cmd >> 16) & 0x1 == 0x1


### PR DESCRIPTION
pylit correctly reports

Data_specification/data_specification_executor_functions.py:95:8: W0238: Unused private member `DataSpecificationExecutorFunctions.__opcode` (unused-private-member)

This pr comments out the opcode.

No more pylint warnings.

Alternatives are of course to remove opcode or to tell plyint to ignore it.