### PR TITLE
Doc link

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,44 +16,18 @@ name: Publish
 
 on:
   push:
-    branches: [ master ]
+    branches: [ doc_link ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Checkout SupportScripts
-      uses: actions/checkout@v3
-      with:
-        repository: SpiNNakerManchester/SupportScripts
-        path: support
-    - name: Install pip, etc
-      uses: ./support/actions/python-tools
-    - name: Install Spinnaker Dependencies
-      uses: ./support/actions/install-spinn-deps
-      with:
-        repositories: SpiNNUtils SpiNNMachine
-        install: true  
-    - name: Setup
-      uses: ./support/actions/run-install
-
-    - name: Build Python Documentation
-      uses: ./support/actions/sphinx
-      with:
-        directory: doc/source
-    - name: Hack for Github Pages
-      run: touch .nojekyll
-      working-directory: doc/source/_build/html
 
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:
         branch: gh-pages
-        folder: doc/source/_build/html
+        folder: doc/global

--- a/.ratexcludes
+++ b/.ratexcludes
@@ -2,3 +2,4 @@
 **/*.dia
 **/SpiNNUtils/**
 **/SpiNNMachine/**
+**/.nojekyll

--- a/README.md
+++ b/README.md
@@ -62,7 +62,5 @@ To be able to run the unitests add [Test] to the pip installs above
 Documentation
 =============
 [DataSpecification python documentation](http://dataspecification.readthedocs.io)
-<br>
-[Alternate location](https://spinnakermanchester.github.io/DataSpecification/)
 
 [Combined python documentation](http://spinnakermanchester.readthedocs.io)

--- a/doc/global/index.html
+++ b/doc/global/index.html
@@ -16,9 +16,9 @@ limitations under the License.
 -->
 <html>
   <head>
-    <meta http-equiv="refresh" content="7; url='http://dataspecification.readthedocs.io/'" />
+    <meta http-equiv="refresh" content="0; url='http://dataspecification.readthedocs.io/'" />
   </head>
   <body>
-    <p>You will be redirected to readthedocs soon!</p>
+    <p>The Documenation is available on <a href="http://dataspecification.readthedocs.io/">readthedocs</a></p>
   </body>
 </html>

--- a/doc/global/index.html
+++ b/doc/global/index.html
@@ -1,0 +1,24 @@
+<html>
+<!--
+Copyright (c) 2023 The University of Manchester
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html>
+  <head>
+    <meta http-equiv="refresh" content="7; url='http://dataspecification.readthedocs.io/'" />
+  </head>
+  <body>
+    <p>You will be redirected to readthedocs soon!</p>
+  </body>
+</html>

--- a/doc/global/index.html
+++ b/doc/global/index.html
@@ -19,6 +19,6 @@ limitations under the License.
     <meta http-equiv="refresh" content="0; url='http://dataspecification.readthedocs.io/'" />
   </head>
   <body>
-    <p>The Documenation is available on <a href="http://dataspecification.readthedocs.io/">readthedocs</a></p>
+    <p>The documentation is available on <a href="http://dataspecification.readthedocs.io/">readthedocs</a></p>
   </body>
 </html>


### PR DESCRIPTION
This pr removed the python docs from github.io

Leaving behind just a redirect at:
https://spinnakermanchester.github.io/DataSpecification/

Not while the publish .yml has been retained it will not run again unless there is a new "doc_link" branch or the on push value is changed.
